### PR TITLE
add phase to final docker image for cicd use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 log
 cache
+cicd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
 # syntax=docker/dockerfile:1
-FROM alpine/curl as deps
+
+# pkl-cli
+FROM alpine/curl AS deps
 
 ARG PKL_VERSION=0.26.1
 RUN curl -L -o /usr/local/bin/pkl https://github.com/apple/pkl/releases/download/${PKL_VERSION}/pkl-alpine-linux-amd64 && chmod +x /usr/local/bin/pkl 
 
-FROM golang:1.22-alpine as builder
+# phase-cli
+FROM phasehq/cli:1.18.1 AS phase
+
+# app builder
+FROM golang:1.22-alpine AS builder
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 COPY *.go ./
 RUN go build -v -o /usr/local/bin/app ./...
 
+# runner
 FROM docker:24
+
+COPY --from=phase /usr/local/bin/phase /usr/local/bin/phase
+COPY --from=phase /usr/local/bin/_internal /usr/local/bin/_internal
 COPY --from=deps /usr/local/bin/pkl /usr/local/bin/pkl
 COPY --from=builder /usr/local/bin/app /usr/local/bin/app
+
 CMD ["app"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+CI/CD
+---
+
+## Running docker on M<X> Macs
+Phase don't have build for arm64 yet, so we need to force docker to use amd64 for now by passing `--platform linux/amd64` to docker commands.
+```
+docker build --platoform linux/amd64 .
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   cicd:
+    platform: linux/amd64
     restart: unless-stopped
     build:
       context: .

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/applyinnovations/cicd
 go 1.21.10
 
 require github.com/go-playground/webhooks/v6 v6.3.0
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,3 +7,5 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -114,6 +114,15 @@ func handleDown(ctx Context) error {
 	return nil
 }
 
+//	func main() {
+//		ctx := generateContext("https://github.com/applyinnovations/ss", "refs/heads/other", "test-main", "")
+//		projectConf, err := getProjectConf(ctx)
+//		if err != nil {
+//			log.Println("failed `getProjectConf`: %w", err)
+//		}
+//		branchConfig := projectConf.getBranchConfig(ctx.branch)
+//		fmt.Printf("environment source: %s value: %s", branchConfig.Environment.Source, branchConfig.Environment.Value)
+//	}
 func main() {
 	err := os.MkdirAll(LOG_DIR, 0755)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -80,6 +80,11 @@ func handleUp(ctx Context) error {
 	if err != nil {
 		return fmt.Errorf("failed `stat docker-compose.yml`: %w", err)
 	}
+	// docker compose up -p sha256(org/repo/branch)
+	err = execCmd("docker", "compose", "--project-directory", cacheDir, "--file", ymlFilePath, "--project-name", ctx.repoBranchSha, "up", "--quiet-pull", "--detach", "--build", "--remove-orphans")
+	if err != nil {
+		return fmt.Errorf("failed `docker compose up`: %w", err)
+	}
 
 	return nil
 }

--- a/project_config.go
+++ b/project_config.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ProjectConf struct {
+	Phase map[string]string `yaml:"phase"`
+}
+
+func (c *ProjectConf) getPhaseEnv(ctx Context) string {
+	// get value of branch in c.Phase if not exist use "*"
+	environment := c.Phase[ctx.branch]
+	if environment == "" {
+		environment = c.Phase["*"]
+	}
+	return environment
+}
+
+func getProjectConf(ctx Context) (projectConf ProjectConf, err error) {
+	c := ProjectConf{}
+	cacheDir := filepath.Join(CACHE_DIR, ctx.commitSha+"-"+ctx.defaultBranch)
+	defer func() {
+		err := os.RemoveAll(cacheDir)
+		if err != nil {
+			log.Printf("failed to remove `%s`\n", cacheDir)
+		}
+	}()
+
+	err = execCmd("git", "clone", "--branch", ctx.defaultBranch, "--single-branch", ctx.repo, cacheDir)
+	if err != nil {
+		return c, fmt.Errorf("failed `git clone`: %w", err)
+	}
+
+	envPklFilePath := filepath.Join(cacheDir, "env.pkl")
+	ymlPklFilePath := filepath.Join(cacheDir, "env.yml")
+
+	err = execCmd("stat", envPklFilePath)
+	if err != nil {
+		return c, nil
+	}
+
+	err = execCmd("pkl", "eval", envPklFilePath, "--format", "yaml", "--output-path", ymlPklFilePath, "--property", "branch="+ctx.branch)
+
+	if err != nil {
+		return c, fmt.Errorf("failed `pkl eval`: %w", err)
+	}
+	out, err := os.ReadFile(ymlPklFilePath)
+	if err != nil {
+		return c, fmt.Errorf("failed to read %+v", err)
+	}
+
+	err = yaml.Unmarshal(out, &c)
+	if err != nil {
+		return c, fmt.Errorf("failed to unmarshal %+v", err)
+	}
+
+	return c, nil
+}

--- a/project_config.go
+++ b/project_config.go
@@ -16,12 +16,12 @@ const (
 )
 
 type EnvironmentProvider struct {
-	source EnvironmentProviderSource `yaml:"type"`
-	value  string                    `yaml:"value"`
+	Source EnvironmentProviderSource `yaml:"source"`
+	Value  string                    `yaml:"value"`
 }
 
 type BranchConfig struct {
-	environment EnvironmentProvider `yaml:"environment"`
+	Environment EnvironmentProvider `yaml:"environment"`
 }
 
 type ProjectConfig map[string]BranchConfig

--- a/util.go
+++ b/util.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+	"os/exec"
+)
+
+func execCmd(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = log.Writer()
+	cmd.Stderr = log.Writer()
+	return cmd.Run()
+}


### PR DESCRIPTION
Added `phase` to the final image for CICD to be able to fetch env from phase.dev.
 - added phasehq/cli image as a step in docker
 - copy phase binary and internals to final image
 - added info about running docker on arm64 machine. phase don't have a usable build for it yet so we need to explicitly tell docker to use amd64 platform for the images.
 - update docker compose to tell cicd docker to use amd64 platform